### PR TITLE
a simple fix for compatibility with rake 0.9.x

### DIFF
--- a/lib/js_test_driver.rb
+++ b/lib/js_test_driver.rb
@@ -2,6 +2,7 @@ require 'multi_json'
 require 'yaml'
 require 'fileutils'
 require 'socket'
+require 'rake'
 
 module JsTestDriver
   autoload :Application, 'js_test_driver/application'


### PR DESCRIPTION
Hey,

I discovered that using js-test-driver-rails with rake 0.9.x causes the following problem:

`/Users/mareknowak/.rvm/gems/ruby-1.9.2-p290@wallboard/gems/js-test-driver-rails-0.4.3/lib/js_test_driver/tasks.rb:3:in `<top (required)>': undefined method `namespace' for main:Object (NoMethodError)`

Googling around I also found out that it may be solved by explicitly requiring 'rake'. Do you think it's an acceptable solution?
